### PR TITLE
Fixed overload for string.Split() for GUIPlanner

### DIFF
--- a/Runtime/GUI/GUIPlanner.cs
+++ b/Runtime/GUI/GUIPlanner.cs
@@ -293,7 +293,7 @@ public class GUIPlanner : EditorWindow
     string GetTypeString(Type type){
         string typeString = type.ToString();
         if (typeString.Contains("_")){
-            return typeString.Split("_")[1];
+            return typeString.Split('_')[1];
         }
         return typeString;
     }


### PR DESCRIPTION
This is a simple fix, because somehow my setup did not like the `string.Split()` overload with a `string` as first argument. `char` overload seems to be a more compatible one that achieves the same thing as the `string` one.